### PR TITLE
support for melodic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_compile_options(-std=c++11)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  eigen_conversions
   moveit_core
   moveit_ros_planning
   roscpp

--- a/package.xml
+++ b/package.xml
@@ -50,6 +50,7 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>eigen_conversions</build_depend>
   <build_depend>opw_kinematics</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -371,7 +371,7 @@ bool MoveItOPWKinematicsPlugin::setOPWParameters()
   std::vector<int> joint_sign_corrections, dummy3;
   if (!lookupParam(prefix + "kinematics_solver_joint_sign_corrections", joint_sign_corrections, dummy3))
   {
-    ROS_ERROR_STREAM("Failed to load joint offsets for ik solver.");
+    ROS_ERROR_STREAM("Failed to load joint sign corrections for ik solver.");
     return false;
   }
 


### PR DESCRIPTION
This enables basic support for ros melodic/the MoveIt! melodic branch. It was just a linker error in the unit test.

Melodic also has new API that allows passing in the RobotModel from your main application (eg respects joint limits given in config/joint-limits.yaml) but that will be handled later in another PR (you probably need a new melodic-devel branch then)