### PR TITLE
Forward kinematics test during initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,4 +111,24 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
     ${MOVEIT_LIB_NAME}
   )
+
+  add_rostest_gtest(${PROJECT_NAME}_test_fanuc_faulty
+    test/test_fanuc_faulty_params.rostest
+    test/test_faulty_params.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_test_fanuc_faulty
+    gtest
+    ${catkin_LIBRARIES}
+    ${MOVEIT_LIB_NAME}
+  )
+
+  add_rostest_gtest(${PROJECT_NAME}_test_kuka_faulty
+    test/test_kuka_faulty_params.rostest
+    test/test_faulty_params.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_test_kuka_faulty
+    gtest
+    ${catkin_LIBRARIES}
+    ${MOVEIT_LIB_NAME}
+  )
 endif()

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -119,7 +119,8 @@ private:
   std::size_t closestJointPose(const std::vector<double>& target,
                                const std::vector<std::vector<double>>& candidates) const;
   bool getAllIK(const Eigen::Isometry3d& pose, std::vector<std::vector<double>>& joint_poses) const;
-  bool getIK(const Eigen::Isometry3d& pose, const std::vector<double>& seed_state, std::vector<double>& joint_pose) const;
+  bool getIK(const Eigen::Isometry3d& pose, const std::vector<double>& seed_state,
+             std::vector<double>& joint_pose) const;
 
   /**
    * @brief append IK solutions by adding +-2pi
@@ -129,6 +130,18 @@ private:
    * therefore this just extends the solution space, need to apply joint limits separately
    */
   void expandIKSolutions(std::vector<std::vector<double>>& solutions) const;
+
+  /**
+   * @brief check forward and inverse kinematics consistency
+   *
+   * A basic tests to check if the geometric parameters loaded at initialization are correct.
+   */
+  bool selfTest();
+
+  /**
+   * @brief check if two poses are the same within an absolute tolerance of 1e-6
+   */
+  bool comparePoses(Eigen::Isometry3d& Ta, Eigen::Isometry3d& Tb);
 
   bool active_; /** Internal variable that indicates whether solvers are configured and ready */
 

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -103,6 +103,13 @@ bool MoveItOPWKinematicsPlugin::initialize(const moveit::core::RobotModel& robot
     return false;
   }
 
+  // check geometric parameters for opw model
+  if (!selfTest())
+  {
+    ROS_ERROR_STREAM_NAMED("opw", "The opw parameters loaded from kinematics.yaml appear to be incorrect.");
+    return false;
+  }
+
   active_ = true;
   ROS_DEBUG_NAMED("opw", "ROS service-based kinematics solver initialized");
   return true;
@@ -147,6 +154,57 @@ int MoveItOPWKinematicsPlugin::getJointIndex(const std::string& name) const
 bool MoveItOPWKinematicsPlugin::timedOut(const ros::WallTime& start_time, double duration) const
 {
   return ((ros::WallTime::now() - start_time).toSec() >= duration);
+}
+
+bool MoveItOPWKinematicsPlugin::selfTest()
+{
+  const std::vector<double> joint_angles = { 0.1, -0.1, 0.2, -0.3, 0.5, -0.8 };
+
+  auto fk_pose_opw = opw_kinematics::forward(opw_parameters_, &joint_angles[0]);
+  robot_state_->setJointGroupPositions(joint_model_group_, joint_angles);
+  auto fk_pose_moveit = robot_state_->getGlobalLinkTransform(tip_frames_[0]);
+
+  if (!comparePoses(fk_pose_opw, fk_pose_moveit))
+  {
+    return false;
+  }
+
+  // reset robot state
+  robot_state_->setToDefaultValues();
+  return true;
+}
+
+bool MoveItOPWKinematicsPlugin::comparePoses(Eigen::Isometry3d& Ta, Eigen::Isometry3d& Tb)
+{
+  const float TOLERANCE = 1e-6;
+
+  auto Ra = Ta.rotation();
+  auto Rb = Tb.rotation();
+  for (int i = 0; i < Ra.rows(); ++i)
+  {
+    for (int j = 0; j < Ra.cols(); ++j)
+    {
+      if (abs(Ra(i, j) - Rb(i, j)) > TOLERANCE)
+      {
+        ROS_ERROR_NAMED("opw", "Pose orientation error on element (%d, %d).", i, j);
+        ROS_ERROR_NAMED("opw", "opw: %f, moveit: %f.", Ra(i, j), Rb(i, j));
+        return false;
+      }
+    }
+  }
+
+  auto pa = Ta.translation();
+  auto pb = Tb.translation();
+  for (int i = 0; i < 3; ++i)
+  {
+    if (abs(pa(i) - pb(i)) > TOLERANCE)
+    {
+      ROS_ERROR_NAMED("opw", "Pose position error on element (%d).", i);
+      ROS_ERROR_NAMED("opw", "opw: %f, moveit: %f.", pa(i), pb(i));
+      return false;
+    }
+  }
+  return true;
 }
 
 bool MoveItOPWKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose,

--- a/test/faulty_kinematics_fanuc.yaml
+++ b/test/faulty_kinematics_fanuc.yaml
@@ -1,0 +1,13 @@
+robot_description_kinematics:
+  manipulator:
+    kinematics_solver: moveit_opw_kinematics_plugin/MoveItOPWKinematicsPlugin
+    kinematics_solver_geometric_parameters:
+      a1:  0.150
+      a2: -0.200
+      b:   0.000
+      c1:  0.450
+      c2:  0.600
+      c3:  0.640
+      c4:  0.100
+    kinematics_solver_joint_offsets: [0, 0, -1.57079632679, 0, 0, 0]
+    kinematics_solver_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/test/faulty_kinematics_kuka.yaml
+++ b/test/faulty_kinematics_kuka.yaml
@@ -1,0 +1,13 @@
+robot_description_kinematics:
+  manipulator:
+    kinematics_solver: moveit_opw_kinematics_plugin/MoveItOPWKinematicsPlugin
+    kinematics_solver_geometric_parameters:
+      a1:  0.025
+      a2: -0.035
+      b:   0.000
+      c1:  0.400
+      c2:  0.315
+      c3:  0.365
+      c4:  0.081
+    kinematics_solver_joint_offsets: [0.0, -1.57079632679, 0, 0, 0, 0]
+    kinematics_solver_joint_sign_corrections: [-1, 1, 1, -1, 1, -1]

--- a/test/kinematics_fanuc.yaml
+++ b/test/kinematics_fanuc.yaml
@@ -9,5 +9,5 @@ robot_description_kinematics:
       c2:  0.600
       c3:  0.640
       c4:  0.100
-    kinematics_solver_joint_offsets: [0.0, -1.57079632679, 0, 0, 0, 0]
+    kinematics_solver_joint_offsets: [0, 0, -1.57079632679, 0, 0, 3.14159265359]
     kinematics_solver_joint_sign_corrections: [1, 1, -1, -1, -1, -1]

--- a/test/test_fanuc_faulty_params.rostest
+++ b/test/test_fanuc_faulty_params.rostest
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+  <arg name="load_robot_description" value="true"/>
+</include>
+
+<rosparam command="load" file="$(find moveit_opw_kinematics_plugin)/test/faulty_kinematics_fanuc.yaml" />
+<param name="tip_link" value="tool0" />
+<param name="root_link" value="base_link" />
+<param name="group" value="manipulator" />
+
+<test pkg="moveit_opw_kinematics_plugin" type="moveit_opw_kinematics_plugin_test_fanuc_faulty" test-name="test_plugin_fanuc_faulty" />
+
+</launch>

--- a/test/test_faulty_params.cpp
+++ b/test/test_faulty_params.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+#include <eigen_conversions/eigen_msg.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h>
+
+// Names to read values from the parameter server
+const std::string GROUP_PARAM = "group";
+const std::string TIP_LINK_PARAM = "tip_link";
+const std::string ROOT_LINK_PARAM = "root_link";
+
+// Robot description almost always called "robot_description" and therefore hardcoded below
+const std::string ROBOT_DESCRIPTION = "robot_description";
+
+class TestPlugin : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    ros::NodeHandle nh;
+    if (nh.getParam(GROUP_PARAM, group_name_) && nh.getParam(ROOT_LINK_PARAM, root_link_) &&
+        nh.getParam(TIP_LINK_PARAM, tip_link_))
+    {
+      rdf_loader::RDFLoader rdf_loader(ROBOT_DESCRIPTION);
+      const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
+      const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
+
+      if (!urdf_model || !srdf)
+      {
+        ROS_ERROR_NAMED("opw", "URDF and SRDF must be loaded for SRV kinematics "
+                               "solver to work.");  // TODO: is this true?
+        return;
+      }
+
+      robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Failed to load parameters necessary to load plugin.");
+    }
+  }
+  void TearDown() override
+  {
+  }
+
+  robot_model::RobotModelPtr robot_model_;
+  moveit_opw_kinematics_plugin::MoveItOPWKinematicsPlugin plugin_;
+  std::string root_link_;
+  std::string tip_link_;
+  std::string group_name_;
+  std::string robot_description_name_;
+};
+
+/** \Brief Initialize plugin when the kinematic parameters loaded are incorrect.
+ *
+ * Therefore initialize should return false. Notice we do not check explicitly
+ * why it fails, but we assumed that it fails because the faulty parameters
+ * where loaded by the rostest launch file.
+ */
+TEST_F(TestPlugin, InitFaulty)
+{
+  // the last parameter specifies "search_discretization", which is not used by the opw plugin
+  bool res = plugin_.initialize(*robot_model_.get(), group_name_, root_link_, { tip_link_ }, 0.1);
+  EXPECT_FALSE(res);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "moveit_opw_kinematics_test_fanuc");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_kuka_faulty_params.rostest
+++ b/test/test_kuka_faulty_params.rostest
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+<include file="$(find kuka_kr6r700_moveit_config)/launch/planning_context.launch">
+  <arg name="load_robot_description" value="true"/>
+</include>
+
+<rosparam command="load" file="$(find moveit_opw_kinematics_plugin)/test/faulty_kinematics_kuka.yaml" />
+<param name="tip_link" value="tool0" />
+<param name="root_link" value="base_link" />
+<param name="group" value="manipulator" />
+
+<test pkg="moveit_opw_kinematics_plugin" type="moveit_opw_kinematics_plugin_test_kuka_faulty" test-name="test_plugin_kuka_faulty"/>
+
+</launch>


### PR DESCRIPTION
As suggested in issue #29 by @simonschmeisser , compare forward kinematics calculated by MoveIt with opw_kinematics. This serves as a basic validation step for the geometric parameters loaded from kinematics.yaml.

Some things I came accros during implementing this.
- The fanuc parameters where wrong, but the current tests did not catch this :s
- The file `moveit_opw_kinematics.cpp` is over 600 lines, maybe factor out some stuff in a header file?

There is also some code duplication in the `comparePoses` function, but it's not entirely the same as the one in `test_util.h` so I think this is ok.

It would also be nice to add a test that load wrong parameters on purpose and checks if the error is show. I don’t know how to do this with the rostest framework yet.

> [edit] I added a basic test that just check whether initialization failed as expected.
> (A lot of test files for a tiny amount of testing...)


I should create a separate pull request for the `kinetic-devel` branch due to the Affine3d-Isometry3d different.