### PR TITLE
Don't prefix param lookup. (#44)

### DIFF
--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -468,29 +468,24 @@ bool MoveItOPWKinematicsPlugin::setOPWParameters()
 {
   ROS_INFO_STREAM("Getting kinematic parameters from parameter server.");
 
-  // Using the full parameter name at the moment because the leading slash
-  // in front of robot_description_kinematics is missing
-  // in lookupParam function, but I'm not sure if this is a bug or I do not
-  // understand the interface.
-  std::string prefix = "/robot_description_kinematics/" + group_name_ + "/";
   ros::NodeHandle nh;
 
   std::map<std::string, double> geometric_parameters, dummy;
-  if (!lookupParam(prefix + "opw_kinematics_geometric_parameters", geometric_parameters, dummy))
+  if (!lookupParam("opw_kinematics_geometric_parameters", geometric_parameters, dummy))
   {
     ROS_ERROR_STREAM("Failed to load geometric parameters for ik solver.");
     return false;
   }
 
   std::vector<double> joint_offsets, dummy2;
-  if (!lookupParam(prefix + "opw_kinematics_joint_offsets", joint_offsets, dummy2))
+  if (!lookupParam("opw_kinematics_joint_offsets", joint_offsets, dummy2))
   {
     ROS_ERROR_STREAM("Failed to load joint offsets for ik solver.");
     return false;
   }
 
   std::vector<int> joint_sign_corrections, dummy3;
-  if (!lookupParam(prefix + "opw_kinematics_joint_sign_corrections", joint_sign_corrections, dummy3))
+  if (!lookupParam("opw_kinematics_joint_sign_corrections", joint_sign_corrections, dummy3))
   {
     ROS_ERROR_STREAM("Failed to load joint sign corrections for ik solver.");
     return false;


### PR DESCRIPTION
#42 
cherry-pick from #44 

Prevents lookupParam(..) from working properly.

Co-authored-by: gavanderhoorn <g.a.vanderhoorn@tudelft.nl>