### PR TITLE
Add opw_kinematics as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/opw_kinematics"]
+	path = external/opw_kinematics
+	url = https://github.com/Jmeyer1292/opw_kinematics.git

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,4 +1,2 @@
-- git: {local-name : opw_kinematics, uri: 'https://github.com/Jmeyer1292/opw_kinematics.git', version: master}
-
 # test dependencies
 - git: {local-name : kuka_test_resources, uri: 'https://github.com/JeroenDM/kuka_test_resources.git', version: master}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
 )
 
-find_package(opw_kinematics REQUIRED)
-
 set(MOVEIT_LIB_NAME moveit_opw_kinematics_plugin)
 
 # System dependencies are found with CMake's conventions
@@ -46,6 +44,7 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(
   include
+  external/opw_kinematics/include
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,7 @@ find_package(Boost REQUIRED COMPONENTS filesystem)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
   LIBRARIES ${MOVEIT_LIB_NAME}
-#  CATKIN_DEPENDS moveit_core moveit_ros_planning roscpp
-#  DEPENDS system_lib
 )
 
 ###########
@@ -66,13 +63,6 @@ install(TARGETS ${MOVEIT_LIB_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-# Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ add_library(${MOVEIT_LIB_NAME}
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   ${catkin_LIBRARIES}
-  opw_kinematics::opw_kinematics
 )
 
 #############

--- a/package.xml
+++ b/package.xml
@@ -26,12 +26,10 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>eigen_conversions</build_depend>
-  <build_depend>opw_kinematics</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
 
-  <build_export_depend>opw_kinematics</build_export_depend>
   <build_export_depend>moveit_core</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
 


### PR DESCRIPTION
This way we do not depend on the release of that package.

- Added opw_kinematics as a submodule in the external directory.
- Removed opw_kinematics from the rosinstall file used by travis.
- Add the include path to CMakeLists, remove all other references to opw_kinematics that are not needed anymore.

Everything was indeed quite straightforward, except for one issue:

>You would want to make sure to not export the include path from the IK plugin's package. Easiest way to do that would be to only include opw_kinematics headers in .cpp files. Never in public headers.

The current implementation requires at least the `#include "opw_kinematics/opw_parameters.h"` in the header file. But I'm not sure I completely understand the issue. The `opw_kinematics` headers are not exported to dependent packages as far as I understand:
```
catkin_package(
  INCLUDE_DIRS include
  LIBRARIES ${MOVEIT_LIB_NAME}
#  CATKIN_DEPENDS moveit_core moveit_ros_planning roscpp
#  DEPENDS system_lib
)
```

The header is required because the plugin has a member variable that contains the opw_parameters [here](https://github.com/JeroenDM/moveit_opw_kinematics_plugin/blob/e35711528a7b3ccecf932aa5bc689b17ea52a6d5/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h#L157). This variable had to be available in multiple methods of the plugin.

