### PR TITLE
Fix test dependency issue with moveit_ros_planning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ add_compile_options(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
   moveit_core
-  moveit_ros_planning
   roscpp
   pluginlib
 )
@@ -89,8 +88,10 @@ install(
 #############
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(moveit_ros_planning REQUIRED)
   find_package(rostest REQUIRED)
-  include_directories(test)
+
+  include_directories(test ${moveit_ros_planning_INCLUDE_DIRS})
   
   add_rostest_gtest(${PROJECT_NAME}_test_kuka
     test/test_kuka.rostest test/test_plugin.cpp
@@ -98,6 +99,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(${PROJECT_NAME}_test_kuka
     gtest
+    ${moveit_ros_planning_LIBRARIES}
     ${catkin_LIBRARIES}
     ${MOVEIT_LIB_NAME}
   )
@@ -108,6 +110,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(${PROJECT_NAME}_test_fanuc
     gtest
+    ${moveit_ros_planning_LIBRARIES}
     ${catkin_LIBRARIES}
     ${MOVEIT_LIB_NAME}
   )
@@ -118,6 +121,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(${PROJECT_NAME}_test_fanuc_faulty
     gtest
+    ${moveit_ros_planning_LIBRARIES}
     ${catkin_LIBRARIES}
     ${MOVEIT_LIB_NAME}
   )
@@ -128,6 +132,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(${PROJECT_NAME}_test_kuka_faulty
     gtest
+    ${moveit_ros_planning_LIBRARIES}
     ${catkin_LIBRARIES}
     ${MOVEIT_LIB_NAME}
   )


### PR DESCRIPTION
The prerelease tests failed because with the error:
```
-- Could not find the required component 'moveit_ros_planning'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by
  "moveit_ros_planning" with any of the following names:

    moveit_ros_planningConfig.cmake
    moveit_ros_planning-config.cmake

  Add the installation prefix of "moveit_ros_planning" to CMAKE_PREFIX_PATH
  or set "moveit_ros_planning_DIR" to a directory containing one of the above
  files.  If "moveit_ros_planning" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:10 (find_package)


-- Configuring incomplete, errors occurred!
```

My assumption is that this is because `moveit_ros_planning` was still under required components in the `CMakeLists.txt`, but it is only a test dependency in the `package.xml`. Moving it to the test section of the `CMakeLists.txt` should solve it, I think. (The tests do depend on it to load the plugin.)

I will try this out in a clean docker container before merging.

Note that I ran the prerelease tests on the branch from #48.