### PR TITLE
Robot on rail plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ include_directories(
 # Declare a C++ library
 add_library(${MOVEIT_LIB_NAME}
   src/moveit_opw_kinematics_plugin.cpp
+  src/moveit_opw_railed_kinematics_plugin.cpp
 )
 
 target_link_libraries(${MOVEIT_LIB_NAME}
@@ -91,7 +92,7 @@ install(
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   include_directories(test)
-  
+
   add_rostest_gtest(${PROJECT_NAME}_test_kuka
     test/test_kuka.rostest test/test_plugin.cpp
     test/test_kuka_specific.cpp

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -32,6 +32,19 @@ using kinematics::KinematicsResult;
 class MoveItOPWKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
+
+  // struct for storing and sorting solutions
+  struct LimitObeyingSol
+  {
+    std::vector<double> value;
+    double dist_from_seed;
+
+    bool operator<(const LimitObeyingSol& a) const
+    {
+      return dist_from_seed < a.dist_from_seed;
+    }
+  };
+
   /**
    *  @brief Default constructor
    */

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -32,6 +32,8 @@ using kinematics::KinematicsResult;
 class MoveItOPWKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
+  friend class MoveItOPWRailedKinematicsPlugin;
+
   // struct for storing and sorting solutions
   struct LimitObeyingSol
   {

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -32,7 +32,6 @@ using kinematics::KinematicsResult;
 class MoveItOPWKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
-
   // struct for storing and sorting solutions
   struct LimitObeyingSol
   {
@@ -136,9 +135,9 @@ private:
 
   bool setOPWParameters();
 
-  double distance(const std::vector<double>& a, const std::vector<double>& b) const;
-  std::size_t closestJointPose(const std::vector<double>& target,
-                               const std::vector<std::vector<double>>& candidates) const;
+  static double distance(const std::vector<double>& a, const std::vector<double>& b);
+  static std::size_t closestJointPose(const std::vector<double>& target,
+                               const std::vector<std::vector<double>>& candidates);
   bool getAllIK(const Eigen::Affine3d& pose, std::vector<std::vector<double>>& joint_poses) const;
   bool getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state, std::vector<double>& joint_pose) const;
 

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -40,35 +40,35 @@ public:
   virtual bool
   getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
                 std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
-                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool searchPositionIK(
       const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
       std::vector<double>& solution, const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
-                             std::vector<geometry_msgs::Pose>& poses) const;
+                             std::vector<geometry_msgs::Pose>& poses) const override;
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& base_name, const std::string& tip_frame, double search_discretization)
+                          const std::string& base_name, const std::string& tip_frame, double search_discretization) override
   {
     std::vector<std::string> tip_frames;
     tip_frames.push_back(tip_frame);
@@ -77,17 +77,17 @@ public:
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& base_name, const std::vector<std::string>& tip_frames,
-                          double search_discretization);
+                          double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
    */
-  const std::vector<std::string>& getJointNames() const;
+  const std::vector<std::string>& getJointNames() const override;
 
   /**
    * @brief  Return all the link names in the order they are represented internally
    */
-  const std::vector<std::string>& getLinkNames() const;
+  const std::vector<std::string>& getLinkNames() const override;
 
   /**
    * @brief  Return all the variable names in the order they are represented internally
@@ -97,7 +97,7 @@ public:
   virtual bool
   getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                 std::vector<std::vector<double>>& solutions, KinematicsResult& result,
-                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
 protected:
   virtual bool
@@ -112,7 +112,7 @@ protected:
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
                    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
-  virtual bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices);
+  virtual bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices) override;
 
 private:
   bool timedOut(const ros::WallTime& start_time, double duration) const;

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h
@@ -1,0 +1,93 @@
+#ifndef MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
+#define MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
+
+#include <moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h>
+
+namespace moveit_opw_kinematics_plugin
+{
+using kinematics::KinematicsResult;
+/**
+ * @brief Specific implementation of kinematics using ROS service calls to communicate with
+   external IK solvers. This version can be used with any robot. Supports non-chain kinematic groups
+ */
+class MoveItOPWRailedKinematicsPlugin : public MoveItOPWKinematicsPlugin
+{
+public:
+  /**
+   *  @brief Default constructor
+   */
+  MoveItOPWRailedKinematicsPlugin();
+
+  virtual bool
+  getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool
+  searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                   std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool
+  searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                   const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                   moveit_msgs::MoveItErrorCodes& error_code,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool searchPositionIK(
+      const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+      std::vector<double>& solution, const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool
+  searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                   const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                   const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
+                             std::vector<geometry_msgs::Pose>& poses) const override;
+
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
+                          const std::string& base_name, const std::string& tip_frame, double search_discretization) override
+  {
+    std::vector<std::string> tip_frames;
+    tip_frames.push_back(tip_frame);
+    return initialize(robot_description, group_name, base_name, tip_frames, search_discretization);
+  }
+
+  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
+                          const std::string& base_name, const std::vector<std::string>& tip_frames,
+                          double search_discretization) override;
+
+  virtual bool
+  getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+                std::vector<std::vector<double>>& solutions, KinematicsResult& result,
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+protected:
+  virtual bool
+  searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                   std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                   moveit_msgs::MoveItErrorCodes& error_code, const std::vector<double>& consistency_limits,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  virtual bool
+  searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+                   double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                   const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
+                   const moveit::core::RobotState* context_state = NULL) const override;
+
+  bool getFreeJointLimits(double& min, double& max) const;
+
+  Eigen::Isometry3d getRobotBaseTransform(const double rail_position) const;
+
+  geometry_msgs::Pose getUpdatedPose(const geometry_msgs::Pose& pose,
+                                     const double rail_position) const;
+
+  std::string free_joint_;
+};
+}  // namespace moveit_opw_kinematics_plugin
+
+#endif // MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h
@@ -1,16 +1,18 @@
-#ifndef MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
-#define MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
+#ifndef MOVEIT_OPW_KINEMATICS_PLUGIN_MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
+#define MOVEIT_OPW_KINEMATICS_PLUGIN_MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
 
 #include <moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
 
 namespace moveit_opw_kinematics_plugin
 {
 using kinematics::KinematicsResult;
+
 /**
- * @brief Specific implementation of kinematics using ROS service calls to communicate with
-   external IK solvers. This version can be used with any robot. Supports non-chain kinematic groups
+ * @brief Kinematics plugin implementation leveraging the MoveItOPWKinematics plugin for robots mounted on a rail
  */
-class MoveItOPWRailedKinematicsPlugin : public MoveItOPWKinematicsPlugin
+class MoveItOPWRailedKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
   /**
@@ -48,8 +50,8 @@ public:
   virtual bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
                              std::vector<geometry_msgs::Pose>& poses) const override;
 
-  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& base_name, const std::string& tip_frame, double search_discretization) override
+  inline virtual bool initialize(const std::string& robot_description, const std::string& group_name,
+                                 const std::string& base_name, const std::string& tip_frame, double search_discretization) override
   {
     std::vector<std::string> tip_frames;
     tip_frames.push_back(tip_frame);
@@ -65,29 +67,61 @@ public:
                 std::vector<std::vector<double>>& solutions, KinematicsResult& result,
                 const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
+  /**
+   * @brief  Return all the joint names in the order they are used internally
+   */
+  const inline std::vector<std::string>& getJointNames() const override
+  {
+    return ik_group_info_.joint_names;
+  }
+
+  /**
+   * @brief  Return all the link names in the order they are represented internally
+   */
+  const inline std::vector<std::string>& getLinkNames() const override
+  {
+    return ik_group_info_.link_names;
+  }
+
 protected:
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    std::vector<double>& solution, const IKCallbackFn& solution_callback,
                    moveit_msgs::MoveItErrorCodes& error_code, const std::vector<double>& consistency_limits,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   virtual bool
   searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                    double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
-                   const moveit::core::RobotState* context_state = NULL) const override;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   bool getFreeJointLimits(double& min, double& max) const;
 
-  Eigen::Isometry3d getRobotBaseTransform(const double rail_position) const;
+  /**
+   * @brief Calculates the transform to the OPW robot base frame at the input rail joint position
+   * @param rail_position - joint positoin of the rail
+   * @return
+   */
+  Eigen::Isometry3d getOPWBaseTransform(const double rail_position) const;
 
+  /**
+   * @brief Calculates the target IK pose in the OPW robot base frame at the input rail joint position
+   * @param pose - target IK pose
+   * @param rail_position - joint position of the rail
+   * @return
+   */
   geometry_msgs::Pose getUpdatedPose(const geometry_msgs::Pose& pose,
                                      const double rail_position) const;
 
-  std::string free_joint_;
+  std::string opw_group_name_;                            /** @brief Name of the planning group that represents the OPW robot */
+  std::string opw_base_frame_;                            /** @brief Name of the OPW robot base frame */
+  moveit_msgs::KinematicSolverInfo ik_group_info_;        /** @brief Solver information */
+  robot_model::RobotModelConstPtr robot_model_;           /** @brief MoveIt robot model */
+  robot_state::RobotStatePtr robot_state_;                /** @brief MoveIt robot state */
+  const robot_model::JointModelGroup* joint_model_group_; /** @brief MoveIt joint model group */
+  MoveItOPWKinematicsPlugin opw_plugin_;                  /** @brief OPW kinematics plugin used for robot kinematics */
 };
 }  // namespace moveit_opw_kinematics_plugin
 
-#endif // MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_
+#endif // MOVEIT_OPW_KINEMATICS_PLUGIN_MOVEIT_OPW_RAILED_KINEMATICS_PLUGIN_

--- a/moveit_opw_kinematics_plugin_description.xml
+++ b/moveit_opw_kinematics_plugin_description.xml
@@ -5,4 +5,10 @@
        based on package opw_kinematics.
     </description>
   </class>
+  <class name="moveit_opw_kinematics_plugin/MoveItOPWRailedKinematicsPlugin" type="moveit_opw_kinematics_plugin::MoveItOPWRailedKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
+    <description>
+      Analytic kinematics for industrial robots on a rail
+       based on package opw_kinematics.
+    </description>
+  </class>
 </library>

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -497,7 +497,7 @@ bool MoveItOPWKinematicsPlugin::setOPWParameters()
   return true;
 }
 
-double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const std::vector<double>& b) const
+double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const std::vector<double>& b)
 {
   double cost = 0.0;
   for (size_t i = 0; i < a.size(); ++i)
@@ -507,7 +507,7 @@ double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const s
 
 // Compute the index of the closest joint pose in 'candidates' from 'target'
 std::size_t MoveItOPWKinematicsPlugin::closestJointPose(const std::vector<double>& target,
-                                                        const std::vector<std::vector<double>>& candidates) const
+                                                        const std::vector<std::vector<double>>& candidates)
 {
   size_t closest = 0;  // index into candidates
   double lowest_cost = std::numeric_limits<double>::max();

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -79,9 +79,9 @@ bool MoveItOPWKinematicsPlugin::initialize(const std::string& robot_description,
                                    << ". Mimic Joint Models: " << joint_model_group_->getMimicJointModels().size());
 
   // Copy joint names
-  for (std::size_t i = 0; i < joint_model_group_->getJointModels().size(); ++i)
+  for (std::size_t i = 0; i < joint_model_group_->getActiveJointModels().size(); ++i)
   {
-    ik_group_info_.joint_names.push_back(joint_model_group_->getJointModelNames()[i]);
+    ik_group_info_.joint_names.push_back(joint_model_group_->getActiveJointModelNames()[i]);
   }
 
   if (debug)

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -339,7 +339,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
   std::vector<std::vector<double>> solutions;
   if (!getAllIK(pose, solutions))
   {
-    ROS_INFO_STREAM_NAMED("opw", "Failed to find IK solution");
+    ROS_DEBUG_STREAM_NAMED("opw", "Failed to find IK solution");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -360,7 +360,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
 
   if (limit_obeying_solutions.empty())
   {
-    ROS_INFO_NAMED("opw", "None of the solutions is within joint limits");
+    ROS_DEBUG_NAMED("opw", "None of the solutions is within joint limits");
     return false;
   }
 
@@ -386,7 +386,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
     }
   }
 
-  ROS_INFO_STREAM_NAMED("opw", "No solution fullfilled requirements of solution callback");
+  ROS_DEBUG_STREAM_NAMED("opw", "No solution fullfilled requirements of solution callback");
   return false;
 }
 

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -300,18 +300,6 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_p
                           options);
 }
 
-// struct for storing and sorting solutions
-struct LimitObeyingSol
-{
-  std::vector<double> value;
-  double dist_from_seed;
-
-  bool operator<(const LimitObeyingSol& a) const
-  {
-    return dist_from_seed < a.dist_from_seed;
-  }
-};
-
 bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                                  const std::vector<double>& ik_seed_state, double /*timeout*/,
                                                  const std::vector<double>& /*consistency_limits*/,

--- a/src/moveit_opw_railed_kinematics_plugin.cpp
+++ b/src/moveit_opw_railed_kinematics_plugin.cpp
@@ -1,0 +1,323 @@
+#include <class_loader/class_loader.hpp>
+#include <moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h>
+
+// URDF, SRDF
+#include <srdfdom/model.h>
+#include <urdf_model/model.h>
+
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/rdf_loader/rdf_loader.h>
+#include <moveit/robot_state/conversions.h>
+
+// Eigen
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <eigen_conversions/eigen_msg.h>
+
+// OPW kinematics
+#include "opw_kinematics/opw_io.h"
+#include "opw_kinematics/opw_kinematics.h"
+#include "opw_kinematics/opw_utilities.h"
+
+// register OPWKinematics as a KinematicsBase implementation
+CLASS_LOADER_REGISTER_CLASS(moveit_opw_kinematics_plugin::MoveItOPWRailedKinematicsPlugin, kinematics::KinematicsBase)
+
+namespace moveit_opw_kinematics_plugin
+{
+using kinematics::KinematicsResult;
+
+MoveItOPWRailedKinematicsPlugin::MoveItOPWRailedKinematicsPlugin() : MoveItOPWKinematicsPlugin()
+{
+}
+
+bool MoveItOPWRailedKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
+                                           const std::string& base_frame, const std::vector<std::string>& tip_frames,
+                                           double search_discretization)
+{
+  bool success = MoveItOPWKinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames,
+                                                       search_discretization);
+
+  if (!success)
+  {
+    ROS_ERROR_STREAM("Failed to initialize");
+    return false;
+  }
+
+  if (!lookupParam<std::string>("free_joint", free_joint_, ""))
+  {
+    ROS_ERROR_STREAM("Failed to get free_joint parameter");
+    return false;
+  }
+
+  num_possible_redundant_joints_ = dimension_ - 6;
+  if (num_possible_redundant_joints_ != 1)
+  {
+    ROS_ERROR_STREAM("Requires only 1 free joint (" << num_possible_redundant_joints_ - 6 << " provided)");
+    return false;
+  }
+
+  setRedundantJoints({ static_cast<unsigned>(getJointIndex(free_joint_)) });
+
+  return success;
+}
+
+bool MoveItOPWRailedKinematicsPlugin::getFreeJointLimits(double& min, double& max) const
+{
+  std::size_t idx;
+  try
+  {
+    auto bounds_vec = joint_model_group_->getActiveJointModelsBounds();
+    idx = getJointIndex(free_joint_);
+    if (bounds_vec.at(idx)->at(0).position_bounded_)
+    {
+      max = bounds_vec.at(idx)->at(0).max_position_;
+      min = bounds_vec.at(idx)->at(0).min_position_;
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Free joint is not position bounded");
+      return false;
+    }
+  }
+  catch (const std::exception& ex)
+  {
+    ROS_ERROR_STREAM(ex.what());
+    return false;
+  }
+
+  return true;
+}
+
+Eigen::Isometry3d MoveItOPWRailedKinematicsPlugin::getRobotBaseTransform(const double rail_position) const
+{
+  robot_state_->setToDefaultValues();
+  std::vector<double> joint_vals;
+  robot_state_->copyJointGroupPositions(group_name_, joint_vals);
+  joint_vals[getJointIndex(free_joint_)] = rail_position;
+  robot_state_->setJointGroupPositions(group_name_, joint_vals);
+
+  // Lookup the transform to the child link of the free joint (i.e. robot base)
+  std::string robot_base = joint_model_group_->getJointModel(free_joint_)->getChildLinkModel()->getName();
+
+  return Eigen::Isometry3d(robot_state_->getFrameTransform(robot_base).matrix());
+}
+
+geometry_msgs::Pose MoveItOPWRailedKinematicsPlugin::getUpdatedPose(const geometry_msgs::Pose& ik_pose,
+                                                                    const double rail_position) const
+{
+  // Get the transform to the robot base
+  Eigen::Isometry3d root_to_robot_base = getRobotBaseTransform(rail_position);
+
+  // Get the transform to the kinematic base link
+  Eigen::Isometry3d root_to_kin_base(robot_state_->getFrameTransform(base_frame_).matrix());
+
+  // Convert the target pose
+  Eigen::Isometry3d pose;
+  tf::poseMsgToEigen(ik_pose, pose);
+
+  // Get the pose relative to the OPW base frame (it comes in relative to the kinematic base frame, i.e. rail base)
+  Eigen::Isometry3d new_pose = (root_to_kin_base.inverse() * root_to_robot_base).inverse() * pose;
+
+  geometry_msgs::Pose new_ik_pose;
+  tf::poseEigenToMsg(new_pose, new_ik_pose);
+
+  return new_ik_pose;
+}
+
+bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, std::vector<double>& solution,
+                                              moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
+{
+  const IKCallbackFn solution_callback = 0;
+  std::vector<double> consistency_limits;
+
+  return searchPositionIK(ik_pose, ik_seed_state, default_timeout_, solution, solution_callback, error_code,
+                          consistency_limits, options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                 const std::vector<double>& ik_seed_state, double timeout,
+                                                 std::vector<double>& solution,
+                                                 moveit_msgs::MoveItErrorCodes& error_code,
+                                                 const kinematics::KinematicsQueryOptions& options) const
+{
+  const IKCallbackFn solution_callback = 0;
+  std::vector<double> consistency_limits;
+
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
+                          options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                 const std::vector<double>& ik_seed_state, double timeout,
+                                                 const std::vector<double>& consistency_limits,
+                                                 std::vector<double>& solution,
+                                                 moveit_msgs::MoveItErrorCodes& error_code,
+                                                 const kinematics::KinematicsQueryOptions& options) const
+{
+  const IKCallbackFn solution_callback = 0;
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
+                          options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                 const std::vector<double>& ik_seed_state, double timeout,
+                                                 std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                                 moveit_msgs::MoveItErrorCodes& error_code,
+                                                 const kinematics::KinematicsQueryOptions& options) const
+{
+  std::vector<double> consistency_limits;
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
+                          options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                 const std::vector<double>& ik_seed_state, double timeout,
+                                                 const std::vector<double>& consistency_limits,
+                                                 std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                                 moveit_msgs::MoveItErrorCodes& error_code,
+                                                 const kinematics::KinematicsQueryOptions& options) const
+{
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, solution, solution_callback, error_code, consistency_limits,
+                          options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                                       const std::vector<double>& ik_seed_state, double timeout,
+                                                       std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                                       moveit_msgs::MoveItErrorCodes& error_code,
+                                                       const std::vector<double>& consistency_limits,
+                                                       const kinematics::KinematicsQueryOptions& options) const
+{
+  // Convert single pose into a vector of one pose
+  std::vector<geometry_msgs::Pose> ik_poses;
+  ik_poses.push_back(ik_pose);
+
+  return searchPositionIK(ik_poses, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
+                          options);
+}
+
+bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                                       const std::vector<double>& ik_seed_state, double timeout,
+                                                       const std::vector<double>& consistency_limits,
+                                                       std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                                       moveit_msgs::MoveItErrorCodes& error_code,
+                                                       const kinematics::KinematicsQueryOptions& options,
+                                                       const moveit::core::RobotState* context_state) const
+{
+  double min, max;
+  if (!getFreeJointLimits(min, max))
+    return false;
+
+  std::vector<LimitObeyingSol> sols;
+
+  std::size_t count = static_cast<std::size_t>(std::floor((max - min) / search_discretization_));
+  for (std::size_t i = 0; i < count; ++i)
+  {
+    double rail_position = min + (i * search_discretization_);
+
+    // Get the IK pose relative to the OPW base frame
+    geometry_msgs::Pose new_ik_pose = getUpdatedPose(ik_poses.front(), rail_position);
+
+    // Solve IK
+    std::vector<double> sol;
+    if (MoveItOPWKinematicsPlugin::searchPositionIK({ new_ik_pose }, ik_seed_state, timeout, consistency_limits, sol, solution_callback,
+                                                    error_code, options, context_state))
+    {
+      sol.insert(sol.begin() + getJointIndex(free_joint_), rail_position);
+      sols.push_back({ sol, distance(sol, ik_seed_state) });
+    }
+  }
+
+  if (sols.empty())
+  {
+    ROS_WARN_STREAM("No solutions found");
+    return false;
+  }
+
+  // Sort the solutions by lowest joint distance from the solution
+  std::sort(sols.begin(), sols.end());
+  solution = sols.front().value;
+
+  return true;
+}
+
+bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                                    const std::vector<double>& ik_seed_state,
+                                                    std::vector<std::vector<double>>& solutions, KinematicsResult&,
+                                                    const kinematics::KinematicsQueryOptions&) const
+{
+  if (ik_poses.size() > 1 || ik_poses.size() == 0)
+  {
+    ROS_ERROR_STREAM_NAMED("opw", "You can only get all solutions for a single pose.");
+    return false;
+  }
+
+  double min, max;
+  if (!getFreeJointLimits(min, max))
+    return false;
+
+  std::vector<LimitObeyingSol> all_sols;
+
+  std::size_t count = static_cast<std::size_t>(std::floor((max - min) / search_discretization_));
+  for (std::size_t i = 0; i < count; ++i)
+  {
+    double rail_position = min + (i * search_discretization_);
+    geometry_msgs::Pose new_ik_pose = getUpdatedPose(ik_poses.front(), rail_position);
+
+    Eigen::Isometry3d new_pose;
+    tf::poseMsgToEigen(new_ik_pose, new_pose);
+
+    // Solve IK
+    std::vector<std::vector<double>> sols;
+    if (MoveItOPWKinematicsPlugin::getAllIK(new_pose, sols))
+    {
+      for (std::vector<double>& sol : sols)
+      {
+        sol.insert(sol.begin() + getJointIndex(free_joint_), rail_position);
+        all_sols.push_back({ sol, distance(sol, ik_seed_state) });
+      }
+    }
+  }
+
+  if (all_sols.empty())
+  {
+    ROS_WARN_STREAM("No solutions found");
+    return false;
+  }
+
+  // Sort the solutions by lowest joint distance from the solution
+  std::sort(all_sols.begin(), all_sols.end());
+
+  solutions.clear();
+  for (const LimitObeyingSol sol : all_sols)
+  {
+    solutions.push_back(sol.value);
+  }
+
+  return true;
+}
+
+bool MoveItOPWRailedKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_names,
+                                                    const std::vector<double>& joint_angles,
+                                                    std::vector<geometry_msgs::Pose>& poses) const
+{
+  std::vector<geometry_msgs::Pose> robot_poses;
+  if (!MoveItOPWKinematicsPlugin::getPositionFK(link_names, joint_angles, robot_poses))
+  {
+    return false;
+  }
+
+  Eigen::Isometry3d robot_base_to_tip;
+  tf::poseMsgToEigen(robot_poses[0], robot_base_to_tip);
+  Eigen::Isometry3d root_to_robot_base = getRobotBaseTransform(joint_angles[getJointIndex(free_joint_)]);
+  Eigen::Isometry3d root_to_tip = root_to_robot_base * robot_base_to_tip;
+
+  poses.resize(link_names.size());
+  tf::poseEigenToMsg(root_to_tip, poses.front());
+
+  return true;
+}
+
+}  // namespace moveit_opw_kinematics_plugin

--- a/src/moveit_opw_railed_kinematics_plugin.cpp
+++ b/src/moveit_opw_railed_kinematics_plugin.cpp
@@ -1,112 +1,148 @@
-#include <class_loader/class_loader.hpp>
 #include <moveit_opw_kinematics_plugin/moveit_opw_railed_kinematics_plugin.h>
 
 // URDF, SRDF
 #include <srdfdom/model.h>
 #include <urdf_model/model.h>
-
-#include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/rdf_loader/rdf_loader.h>
-#include <moveit/robot_state/conversions.h>
 
 // Eigen
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include <eigen_conversions/eigen_msg.h>
 
-// OPW kinematics
-#include "opw_kinematics/opw_io.h"
-#include "opw_kinematics/opw_kinematics.h"
-#include "opw_kinematics/opw_utilities.h"
-
-// register OPWKinematics as a KinematicsBase implementation
-CLASS_LOADER_REGISTER_CLASS(moveit_opw_kinematics_plugin::MoveItOPWRailedKinematicsPlugin, kinematics::KinematicsBase)
+static const std::string LOG_NAMESPACE = "opw_railed";
 
 namespace moveit_opw_kinematics_plugin
 {
 using kinematics::KinematicsResult;
 
-MoveItOPWRailedKinematicsPlugin::MoveItOPWRailedKinematicsPlugin() : MoveItOPWKinematicsPlugin()
+MoveItOPWRailedKinematicsPlugin::MoveItOPWRailedKinematicsPlugin() : kinematics::KinematicsBase ()
 {
 }
 
 bool MoveItOPWRailedKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
-                                           const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                                           double search_discretization)
+                                                 const std::string& base_frame,
+                                                 const std::vector<std::string>& tip_frames,
+                                                 double search_discretization)
 {
-  bool success = MoveItOPWKinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames,
-                                                       search_discretization);
+  ROS_INFO_STREAM_NAMED(LOG_NAMESPACE, "MoveItOPWRailedKinematicsPlugin initializing");
 
-  if (!success)
+  setValues(robot_description, group_name, base_frame, tip_frames, search_discretization);
+
+  // Initialize MoveIt objects
+  rdf_loader::RDFLoader rdf_loader(robot_description_);
+  const srdf::ModelSharedPtr& srdf = rdf_loader.getSRDF();
+  const urdf::ModelInterfaceSharedPtr& urdf_model = rdf_loader.getURDF();
+
+  if (!urdf_model || !srdf)
   {
-    ROS_ERROR_STREAM("Failed to initialize");
+    ROS_ERROR_NAMED(LOG_NAMESPACE, "URDF and SRDF must be loaded for OPWMoveItRailedKinematicsPlugin kinematics "
+                                   "solver to work.");
     return false;
   }
 
-  if (!lookupParam<std::string>("free_joint", free_joint_, ""))
-  {
-    ROS_ERROR_STREAM("Failed to get free_joint parameter");
+  robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
+  robot_state_.reset(new robot_state::RobotState(robot_model_));
+
+  joint_model_group_ = robot_model_->getJointModelGroup(group_name);
+  if (!joint_model_group_)
     return false;
+
+  // Copy joint names
+  for (std::size_t i = 0; i < joint_model_group_->getActiveJointModels().size(); ++i)
+  {
+    ik_group_info_.joint_names.push_back(joint_model_group_->getActiveJointModelNames()[i]);
   }
 
-  num_possible_redundant_joints_ = dimension_ - 6;
-  if (num_possible_redundant_joints_ != 1)
+  // Make sure all the tip links are in the link_names vector
+  for (std::size_t i = 0; i < tip_frames_.size(); ++i)
   {
-    ROS_ERROR_STREAM("Requires only 1 free joint (" << num_possible_redundant_joints_ - 6 << " provided)");
-    return false;
-  }
-
-  setRedundantJoints({ static_cast<unsigned>(getJointIndex(free_joint_)) });
-
-  return success;
-}
-
-bool MoveItOPWRailedKinematicsPlugin::getFreeJointLimits(double& min, double& max) const
-{
-  std::size_t idx;
-  try
-  {
-    auto bounds_vec = joint_model_group_->getActiveJointModelsBounds();
-    idx = getJointIndex(free_joint_);
-    if (bounds_vec.at(idx)->at(0).position_bounded_)
+    if (!joint_model_group_->hasLinkModel(tip_frames_[i]))
     {
-      max = bounds_vec.at(idx)->at(0).max_position_;
-      min = bounds_vec.at(idx)->at(0).min_position_;
-    }
-    else
-    {
-      ROS_ERROR_STREAM("Free joint is not position bounded");
+      ROS_ERROR_NAMED("opw", "Could not find tip name '%s' in joint group '%s'", tip_frames_[i].c_str(),
+                      group_name.c_str());
       return false;
     }
+    ik_group_info_.link_names.push_back(tip_frames_[i]);
   }
-  catch (const std::exception& ex)
+
+  // Get the OPW planning group (planning group for only the OPW joints, unlike the input group which includes a rail joint)
+  const std::string opw_group_name_param = "opw_group";
+  if (!lookupParam<std::string>(opw_group_name_param, opw_group_name_, ""))
   {
-    ROS_ERROR_STREAM(ex.what());
+    ROS_ERROR_STREAM_NAMED(LOG_NAMESPACE, "Failed to get " << opw_group_name_param << "' parameter");
+    return false;
+  }
+  auto opw_joint_model_group = robot_model_->getJointModelGroup(opw_group_name_);
+  if (!opw_joint_model_group)
+    return false;
+
+  opw_base_frame_ = opw_joint_model_group->getActiveJointModels().front()->getParentLinkModel()->getName();
+
+  // Get the difference between the input planning group and the specified OPW group, which represents the free joint(s)
+  std::vector<std::string> active_joint_diff;
+  std::set_difference(joint_model_group_->getActiveJointModelNames().begin(),
+                      joint_model_group_->getActiveJointModelNames().end(),
+                      opw_joint_model_group->getActiveJointModelNames().begin(),
+                      opw_joint_model_group->getActiveJointModelNames().end(),
+                      std::inserter(active_joint_diff, active_joint_diff.begin()));
+
+  if (active_joint_diff.size() != 1)
+  {
+    ROS_ERROR_STREAM_NAMED(LOG_NAMESPACE, "The MoveItOPWRailedKinematics plugin requires only 1 free joint (" << active_joint_diff.size() << " detected)");
+    return false;
+  }
+
+  // Initialize the OPW plugin with the group that represents the OPW manipulator (the input joint group should have additional joints)
+  if(!opw_plugin_.initialize(robot_description, opw_group_name_, opw_base_frame_, tip_frames, search_discretization))
+  {
+    ROS_ERROR_STREAM_NAMED(LOG_NAMESPACE, "Failed to initialize MoveItOPWKinematicsSolver for railed solver");
     return false;
   }
 
   return true;
 }
 
-Eigen::Isometry3d MoveItOPWRailedKinematicsPlugin::getRobotBaseTransform(const double rail_position) const
+bool MoveItOPWRailedKinematicsPlugin::getFreeJointLimits(double& min, double& max) const
+{
+  try
+  {
+    auto bounds_vec = joint_model_group_->getActiveJointModelsBounds();
+    if (bounds_vec.at(0)->at(0).position_bounded_)
+    {
+      max = bounds_vec.at(0)->at(0).max_position_;
+      min = bounds_vec.at(0)->at(0).min_position_;
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED(LOG_NAMESPACE, "Free joint is not position bounded");
+      return false;
+    }
+  }
+  catch (const std::exception& ex)
+  {
+    ROS_ERROR_STREAM_NAMED("opw_", ex.what());
+    return false;
+  }
+
+  return true;
+}
+
+Eigen::Isometry3d MoveItOPWRailedKinematicsPlugin::getOPWBaseTransform(const double rail_position) const
 {
   robot_state_->setToDefaultValues();
   std::vector<double> joint_vals;
   robot_state_->copyJointGroupPositions(group_name_, joint_vals);
-  joint_vals[getJointIndex(free_joint_)] = rail_position;
+  joint_vals[0] = rail_position;
   robot_state_->setJointGroupPositions(group_name_, joint_vals);
 
-  // Lookup the transform to the child link of the free joint (i.e. robot base)
-  std::string robot_base = joint_model_group_->getJointModel(free_joint_)->getChildLinkModel()->getName();
-
-  return Eigen::Isometry3d(robot_state_->getFrameTransform(robot_base).matrix());
+  // Lookup the transform to the OPW base link
+  return Eigen::Isometry3d(robot_state_->getFrameTransform(opw_base_frame_).matrix());
 }
 
 geometry_msgs::Pose MoveItOPWRailedKinematicsPlugin::getUpdatedPose(const geometry_msgs::Pose& ik_pose,
                                                                     const double rail_position) const
 {
   // Get the transform to the robot base
-  Eigen::Isometry3d root_to_robot_base = getRobotBaseTransform(rail_position);
+  Eigen::Isometry3d root_to_opw_base = getOPWBaseTransform(rail_position);
 
   // Get the transform to the kinematic base link
   Eigen::Isometry3d root_to_kin_base(robot_state_->getFrameTransform(base_frame_).matrix());
@@ -116,7 +152,7 @@ geometry_msgs::Pose MoveItOPWRailedKinematicsPlugin::getUpdatedPose(const geomet
   tf::poseMsgToEigen(ik_pose, pose);
 
   // Get the pose relative to the OPW base frame (it comes in relative to the kinematic base frame, i.e. rail base)
-  Eigen::Isometry3d new_pose = (root_to_kin_base.inverse() * root_to_robot_base).inverse() * pose;
+  Eigen::Isometry3d new_pose = (root_to_kin_base.inverse() * root_to_opw_base).inverse() * pose;
 
   geometry_msgs::Pose new_ik_pose;
   tf::poseEigenToMsg(new_pose, new_ik_pose);
@@ -203,16 +239,17 @@ bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const std::vector<geometr
                                                        const std::vector<double>& consistency_limits,
                                                        std::vector<double>& solution, const IKCallbackFn& solution_callback,
                                                        moveit_msgs::MoveItErrorCodes& error_code,
-                                                       const kinematics::KinematicsQueryOptions& options,
-                                                       const moveit::core::RobotState* context_state) const
+                                                       const kinematics::KinematicsQueryOptions& options) const
 {
   double min, max;
   if (!getFreeJointLimits(min, max))
     return false;
 
-  std::vector<LimitObeyingSol> sols;
-
   std::size_t count = static_cast<std::size_t>(std::floor((max - min) / search_discretization_));
+  std::vector<MoveItOPWKinematicsPlugin::LimitObeyingSol> sols;
+  sols.reserve(count);
+
+  std::vector<double> opw_seed_state(ik_seed_state.begin() + 1, ik_seed_state.end());
   for (std::size_t i = 0; i < count; ++i)
   {
     double rail_position = min + (i * search_discretization_);
@@ -220,19 +257,34 @@ bool MoveItOPWRailedKinematicsPlugin::searchPositionIK(const std::vector<geometr
     // Get the IK pose relative to the OPW base frame
     geometry_msgs::Pose new_ik_pose = getUpdatedPose(ik_poses.front(), rail_position);
 
-    // Solve IK
-    std::vector<double> sol;
-    if (MoveItOPWKinematicsPlugin::searchPositionIK({ new_ik_pose }, ik_seed_state, timeout, consistency_limits, sol, solution_callback,
-                                                    error_code, options, context_state))
+    // Solve IK using the OPW plugin
+    // Pass an "empty" callback as the solution callback for the OPW plugin; the solution_callback should be checked
+    // with the full joint state, not just the OPW joints
+    MoveItOPWKinematicsPlugin::LimitObeyingSol sol;
+    if (opw_plugin_.searchPositionIK({ new_ik_pose }, opw_seed_state, timeout, consistency_limits, sol.value, 0,
+                                     error_code, options))
     {
-      sol.insert(sol.begin() + getJointIndex(free_joint_), rail_position);
-      sols.push_back({ sol, distance(sol, ik_seed_state) });
+      sol.value.insert(sol.value.begin(), rail_position);
+
+      // Check the full solution using the provided callback
+      if (solution_callback)
+      {
+        moveit_msgs::MoveItErrorCodes tmp_error;
+        solution_callback(ik_poses.front(), sol.value, tmp_error);
+        if (tmp_error.val != moveit_msgs::MoveItErrorCodes::SUCCESS)
+          continue;
+      }
+
+      // Order the solutions according to their distance from the seed state
+      sol.dist_from_seed = MoveItOPWKinematicsPlugin::distance(sol.value, ik_seed_state);
+      sols.push_back(sol);
     }
   }
 
   if (sols.empty())
   {
-    ROS_WARN_STREAM("No solutions found");
+    ROS_WARN_STREAM_NAMED(LOG_NAMESPACE, "No IK solutions found");
+    error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
     return false;
   }
 
@@ -250,7 +302,7 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const std::vector<geometry_m
 {
   if (ik_poses.size() > 1 || ik_poses.size() == 0)
   {
-    ROS_ERROR_STREAM_NAMED("opw", "You can only get all solutions for a single pose.");
+    ROS_ERROR_STREAM_NAMED(LOG_NAMESPACE, "You can only get all solutions for a single pose.");
     return false;
   }
 
@@ -258,7 +310,7 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const std::vector<geometry_m
   if (!getFreeJointLimits(min, max))
     return false;
 
-  std::vector<LimitObeyingSol> all_sols;
+  std::vector<MoveItOPWKinematicsPlugin::LimitObeyingSol> all_sols;
 
   std::size_t count = static_cast<std::size_t>(std::floor((max - min) / search_discretization_));
   for (std::size_t i = 0; i < count; ++i)
@@ -271,19 +323,19 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const std::vector<geometry_m
 
     // Solve IK
     std::vector<std::vector<double>> sols;
-    if (MoveItOPWKinematicsPlugin::getAllIK(new_pose, sols))
+    if (opw_plugin_.getAllIK(new_pose, sols))
     {
       for (std::vector<double>& sol : sols)
       {
-        sol.insert(sol.begin() + getJointIndex(free_joint_), rail_position);
-        all_sols.push_back({ sol, distance(sol, ik_seed_state) });
+        sol.insert(sol.begin(), rail_position);
+        all_sols.push_back({ sol, MoveItOPWKinematicsPlugin::distance(sol, ik_seed_state) });
       }
     }
   }
 
   if (all_sols.empty())
   {
-    ROS_WARN_STREAM("No solutions found");
+    ROS_WARN_STREAM_NAMED(LOG_NAMESPACE, "No solutions found");
     return false;
   }
 
@@ -291,7 +343,7 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionIK(const std::vector<geometry_m
   std::sort(all_sols.begin(), all_sols.end());
 
   solutions.clear();
-  for (const LimitObeyingSol sol : all_sols)
+  for (const MoveItOPWKinematicsPlugin::LimitObeyingSol sol : all_sols)
   {
     solutions.push_back(sol.value);
   }
@@ -304,15 +356,15 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionFK(const std::vector<std::strin
                                                     std::vector<geometry_msgs::Pose>& poses) const
 {
   std::vector<geometry_msgs::Pose> robot_poses;
-  if (!MoveItOPWKinematicsPlugin::getPositionFK(link_names, joint_angles, robot_poses))
+  if (!opw_plugin_.getPositionFK(link_names, joint_angles, robot_poses))
   {
     return false;
   }
 
   Eigen::Isometry3d robot_base_to_tip;
   tf::poseMsgToEigen(robot_poses[0], robot_base_to_tip);
-  Eigen::Isometry3d root_to_robot_base = getRobotBaseTransform(joint_angles[getJointIndex(free_joint_)]);
-  Eigen::Isometry3d root_to_tip = root_to_robot_base * robot_base_to_tip;
+  Eigen::Isometry3d root_to_opw_base = getOPWBaseTransform(joint_angles[0]);
+  Eigen::Isometry3d root_to_tip = root_to_opw_base * robot_base_to_tip;
 
   poses.resize(link_names.size());
   tf::poseEigenToMsg(root_to_tip, poses.front());
@@ -321,3 +373,7 @@ bool MoveItOPWRailedKinematicsPlugin::getPositionFK(const std::vector<std::strin
 }
 
 }  // namespace moveit_opw_kinematics_plugin
+
+// register as a KinematicsBase implementation
+#include <class_loader/register_macro.hpp>
+CLASS_LOADER_REGISTER_CLASS(moveit_opw_kinematics_plugin::MoveItOPWRailedKinematicsPlugin, kinematics::KinematicsBase)


### PR DESCRIPTION
This PR implements a new OPW kinematics plugin specifically for OPW robots mounted on a single external axis. The plugin samples the external axis at the specified discretization and uses the OPW kinematics plugin to solve IK at each discrete joint position, returning the solution closest to the seed in joint space.

This plugin is configured with the existing OPW parameters as well as a string for the planning group of the OPW robot. The assumption is that a separate planning group exists which defines only the OPW robot joints. Currently only a single external axis is supported, but this plugin could be modified relatively easily to work with an arbitrary number of external axis joints