### PR TITLE
Minor Improvements

### DIFF
--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -32,6 +32,19 @@ using kinematics::KinematicsResult;
 class MoveItOPWKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
+
+  // struct for storing and sorting solutions
+  struct LimitObeyingSol
+  {
+    std::vector<double> value;
+    double dist_from_seed;
+
+    bool operator<(const LimitObeyingSol& a) const
+    {
+      return dist_from_seed < a.dist_from_seed;
+    }
+  };
+
   /**
    *  @brief Default constructor
    */

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -32,7 +32,6 @@ using kinematics::KinematicsResult;
 class MoveItOPWKinematicsPlugin : public kinematics::KinematicsBase
 {
 public:
-
   // struct for storing and sorting solutions
   struct LimitObeyingSol
   {
@@ -136,9 +135,9 @@ private:
 
   bool setOPWParameters();
 
-  double distance(const std::vector<double>& a, const std::vector<double>& b) const;
-  std::size_t closestJointPose(const std::vector<double>& target,
-                               const std::vector<std::vector<double>>& candidates) const;
+  static double distance(const std::vector<double>& a, const std::vector<double>& b);
+  static std::size_t closestJointPose(const std::vector<double>& target,
+                               const std::vector<std::vector<double>>& candidates);
   bool getAllIK(const Eigen::Affine3d& pose, std::vector<std::vector<double>>& joint_poses) const;
   bool getIK(const Eigen::Affine3d& pose, const std::vector<double>& seed_state, std::vector<double>& joint_pose) const;
 

--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -40,35 +40,35 @@ public:
   virtual bool
   getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
                 std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
-                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool searchPositionIK(
       const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
       std::vector<double>& solution, const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+      const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool
   searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
                    const std::vector<double>& consistency_limits, std::vector<double>& solution,
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
-                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                   const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
   virtual bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
-                             std::vector<geometry_msgs::Pose>& poses) const;
+                             std::vector<geometry_msgs::Pose>& poses) const override;
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& base_name, const std::string& tip_frame, double search_discretization)
+                          const std::string& base_name, const std::string& tip_frame, double search_discretization) override
   {
     std::vector<std::string> tip_frames;
     tip_frames.push_back(tip_frame);
@@ -77,17 +77,17 @@ public:
 
   virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                           const std::string& base_name, const std::vector<std::string>& tip_frames,
-                          double search_discretization);
+                          double search_discretization) override;
 
   /**
    * @brief  Return all the joint names in the order they are used internally
    */
-  const std::vector<std::string>& getJointNames() const;
+  const std::vector<std::string>& getJointNames() const override;
 
   /**
    * @brief  Return all the link names in the order they are represented internally
    */
-  const std::vector<std::string>& getLinkNames() const;
+  const std::vector<std::string>& getLinkNames() const override;
 
   /**
    * @brief  Return all the variable names in the order they are represented internally
@@ -97,7 +97,7 @@ public:
   virtual bool
   getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                 std::vector<std::vector<double>>& solutions, KinematicsResult& result,
-                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
+                const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
 protected:
   virtual bool
@@ -112,7 +112,7 @@ protected:
                    const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
                    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
-  virtual bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices);
+  virtual bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices) override;
 
 private:
   bool timedOut(const ros::WallTime& start_time, double duration) const;

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -497,7 +497,7 @@ bool MoveItOPWKinematicsPlugin::setOPWParameters()
   return true;
 }
 
-double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const std::vector<double>& b) const
+double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const std::vector<double>& b)
 {
   double cost = 0.0;
   for (size_t i = 0; i < a.size(); ++i)
@@ -507,7 +507,7 @@ double MoveItOPWKinematicsPlugin::distance(const std::vector<double>& a, const s
 
 // Compute the index of the closest joint pose in 'candidates' from 'target'
 std::size_t MoveItOPWKinematicsPlugin::closestJointPose(const std::vector<double>& target,
-                                                        const std::vector<std::vector<double>>& candidates) const
+                                                        const std::vector<std::vector<double>>& candidates)
 {
   size_t closest = 0;  // index into candidates
   double lowest_cost = std::numeric_limits<double>::max();

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -79,9 +79,9 @@ bool MoveItOPWKinematicsPlugin::initialize(const std::string& robot_description,
                                    << ". Mimic Joint Models: " << joint_model_group_->getMimicJointModels().size());
 
   // Copy joint names
-  for (std::size_t i = 0; i < joint_model_group_->getJointModels().size(); ++i)
+  for (std::size_t i = 0; i < joint_model_group_->getActiveJointModels().size(); ++i)
   {
-    ik_group_info_.joint_names.push_back(joint_model_group_->getJointModelNames()[i]);
+    ik_group_info_.joint_names.push_back(joint_model_group_->getActiveJointModelNames()[i]);
   }
 
   if (debug)

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -339,7 +339,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
   std::vector<std::vector<double>> solutions;
   if (!getAllIK(pose, solutions))
   {
-    ROS_INFO_STREAM_NAMED("opw", "Failed to find IK solution");
+    ROS_DEBUG_STREAM_NAMED("opw", "Failed to find IK solution");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -360,7 +360,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
 
   if (limit_obeying_solutions.empty())
   {
-    ROS_INFO_NAMED("opw", "None of the solutions is within joint limits");
+    ROS_DEBUG_NAMED("opw", "None of the solutions is within joint limits");
     return false;
   }
 
@@ -386,7 +386,7 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs
     }
   }
 
-  ROS_INFO_STREAM_NAMED("opw", "No solution fullfilled requirements of solution callback");
+  ROS_DEBUG_STREAM_NAMED("opw", "No solution fullfilled requirements of solution callback");
   return false;
 }
 

--- a/src/moveit_opw_kinematics_plugin.cpp
+++ b/src/moveit_opw_kinematics_plugin.cpp
@@ -300,18 +300,6 @@ bool MoveItOPWKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_p
                           options);
 }
 
-// struct for storing and sorting solutions
-struct LimitObeyingSol
-{
-  std::vector<double> value;
-  double dist_from_seed;
-
-  bool operator<(const LimitObeyingSol& a) const
-  {
-    return dist_from_seed < a.dist_from_seed;
-  }
-};
-
 bool MoveItOPWKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
                                                  const std::vector<double>& ik_seed_state, double /*timeout*/,
                                                  const std::vector<double>& /*consistency_limits*/,


### PR DESCRIPTION
Minor improvements to the OPW kinematics plugin. The primary changes are to facilitate the development of the [railed kinematics plugin](#52 ):
  - Moving the `LimitObeyingSols` struct to the header so it can be used by other classes
  - Making distance calculation utility functions static for use by other classes

@JeroenDM should I also make a similar PR against the `melodic-devel` branch with these changes?