### PR TITLE
specify C++14 in a new more cross-platform way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_opw_kinematics_plugin)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
This change matches how the C++ standard is specified in [moveit_kinematics](https://github.com/ros-planning/moveit/blob/dfb00da5917f357f56b54db5b0e3038a3180e10a/moveit_kinematics/CMakeLists.txt#L4), as discussed in #48.

```C++
set(CMAKE_CXX_STANDARD 14)
set(CMAKE_CXX_STANDARD_REQUIRED ON)
set(CMAKE_CXX_EXTENSIONS OFF)
```

Ideally, I would like to test this on an msvc compiler, but I did not look into it yet. Maybe some of the dependencies are not supported yet.