### PR TITLE
Prepare noetic release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/opw_kinematics"]
-	path = external/opw_kinematics
-	url = https://github.com/Jmeyer1292/opw_kinematics.git

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,23 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package moveit_opw_kinematics_plugin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* First release in noetic.
+* update to new opw_kinematics API (with std::array)
+* Add opw_kinematics dependency to package.xml and CMakeLists.txt.
+* Remove opw_kinematics submodule.
+* Change moveit_resources to more specific moveit_resources_fanuc_moveit_config
+* Minor changes:
+  - It's not a service based IK solver.
+  - Parameters don't always come from 'kinematics.yaml'.
+* Contributors: JeroenDM, gavanderhoorn.
+
+0.2.1 (2020-05-13)
+------------------
+* First release in melodic.
+
+0.1.1 (2020-05-13)
+------------------
+* First release in kinetic.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(
   include
-  external/opw_kinematics/include
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(MOVEIT_LIB_NAME moveit_opw_kinematics_plugin)
 # System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
+find_package(opw_kinematics REQUIRED)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -52,6 +54,7 @@ add_library(${MOVEIT_LIB_NAME}
 
 target_link_libraries(${MOVEIT_LIB_NAME}
   ${catkin_LIBRARIES}
+  opw_kinematics::opw_kinematics
 )
 
 #############

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>opw_kinematics</build_depend>
 
   <build_export_depend>moveit_core</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_opw_kinematics_plugin</name>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <description>
     <p>
       MoveIt kinematics plugin for industrial robots.


### PR DESCRIPTION
TODO for noetic version:

- [x] Remove opw_kinematics submodule and add it as a released dependency. (Figure out how to correctly add it in CMakeList.txt.)
- [x] Check if tests run on noetic (figure out the problem with the missing `industrial_robot_client` package on noetic to make `kuka_test_resources` work) (**Solution**: I build industrial_robot_client from source).
- [x] Run prerelease tests.
- [x] Update changelog
- [x] Add to rosdistro index

[Link](http://wiki.ros.org/bloom/Tutorials/FirstTimeRelease) to release doc.