### PR TITLE
Bugfix: make joint bound checks threadsafe

### DIFF
--- a/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
+++ b/include/moveit_opw_kinematics_plugin/moveit_opw_kinematics_plugin.h
@@ -163,8 +163,6 @@ private:
 
   const robot_model::JointModelGroup* joint_model_group_;
 
-  robot_state::RobotStatePtr robot_state_;
-
   int num_possible_redundant_joints_;
 
   opw_kinematics::Parameters<double> opw_parameters_;


### PR DESCRIPTION
Use a (thread local) copy of robot state for checking joint bounds instead of a pointer to the same robot state instance.
Since robot state gets modified during bound check, good solutions may have been discarded when using IK in multiple threads concurrently.