### PR TITLE
Dont enforce C++ 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_opw_kinematics_plugin)
 
-set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
it has been the default for some while and newer versions of log4cxx require C++ 17

part of the ROS-O project